### PR TITLE
Fixes wget issue on OSX

### DIFF
--- a/corona-rocks.sh
+++ b/corona-rocks.sh
@@ -55,7 +55,8 @@ mkdir -p "${PREFIX}/${BASE}/lib"
 ###############################################################################
 cd /tmp
 
-wget -q "http://keplerproject.github.io/luarocks/releases/${LUAROCKS}.tar.gz"
+# Fix for OSX Yosemite and above which do not come with wget installed 
+wget -q "http://keplerproject.github.io/luarocks/releases/${LUAROCKS}.tar.gz" 2>/dev/null || curl -O  "http://keplerproject.github.io/luarocks/releases/${LUAROCKS}.tar.gz"
 tar xzf "${LUAROCKS}.tar.gz"
 cd $LUAROCKS
 


### PR DESCRIPTION
OSx does not natively have wget installed, users could use home-brew or another alternative. Probably better just to alternatively use curl if wget not available.